### PR TITLE
Added force exit for Windows 8.1 hanging issue.

### DIFF
--- a/platform-specific/turnoff_win8.1.py
+++ b/platform-specific/turnoff_win8.1.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import win32gui
+import win32con
+from os import getpid, system
+from threading import Timer
+
+def force_exit():
+    pid = getpid()
+    system('taskkill /pid %s /f' % pid)
+
+t = Timer(1, force_exit)
+t.start()
+SC_MONITORPOWER = 0xF170
+win32gui.SendMessage(win32con.HWND_BROADCAST, win32con.WM_SYSCOMMAND, SC_MONITORPOWER, 2)
+t.cancel()


### PR DESCRIPTION
Waits 1 second then force terminates the script, leaving monitor(s) off.
If script doesn't hang then t.cancel() cancels force terminate and script terminates naturally.