### PR TITLE
use SendMessageTimeout instead of SendMessage to avoid blocking

### DIFF
--- a/platform-specific/turnoff_win32.py
+++ b/platform-specific/turnoff_win32.py
@@ -2,4 +2,9 @@ import win32gui
 import win32con
 
 SC_MONITORPOWER = 0xF170
-win32gui.SendMessage(win32con.HWND_BROADCAST, win32con.WM_SYSCOMMAND, SC_MONITORPOWER, 2)
+# win32gui.SendMessage(win32con.HWND_BROADCAST, win32con.WM_SYSCOMMAND, SC_MONITORPOWER, 2)
+win32gui.SendMessageTimeout(win32con.HWND_BROADCAST,
+    win32con.WM_SYSCOMMAND, 
+    SC_MONITORPOWER, 2, 
+    win32con.SMTO_NOTIMEOUTIFNOTHUNG, 
+    1000)

--- a/turnoff.py
+++ b/turnoff.py
@@ -8,18 +8,12 @@ if sys.platform.startswith('linux'):
 elif sys.platform.startswith('win'):
 	import win32gui
 	import win32con
-	from os import getpid, system
-	from threading import Timer
-	
-	def force_exit():
-		pid = getpid()
-		system('taskkill /pid %s /f' % pid)
-	
-	t = Timer(1, force_exit)
-	t.start()
 	SC_MONITORPOWER = 0xF170
-	win32gui.SendMessage(win32con.HWND_BROADCAST, win32con.WM_SYSCOMMAND, SC_MONITORPOWER, 2)
-	t.cancel()
+	win32gui.SendMessageTimeout(win32con.HWND_BROADCAST,
+		win32con.WM_SYSCOMMAND, 
+		SC_MONITORPOWER, 2, 
+		win32con.SMTO_NOTIMEOUTIFNOTHUNG, 
+		1000)
 
 elif sys.platform.startswith('darwin'):
 	import subprocess


### PR DESCRIPTION
using sendmessagetimeout you can avoid the hung process, this example just times out after 1 second (1000ms)